### PR TITLE
Demonstrate AndroidX support with Hilt.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,9 +48,11 @@ dependencies {
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     debugImplementation 'androidx.fragment:fragment-testing:1.2.4'
 
-
+    implementation "androidx.hilt:hilt-common:1.0.0-SNAPSHOT"
+    implementation "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-SNAPSHOT"
     implementation 'com.google.dagger:hilt-android:2.28-alpha'
     kapt 'com.google.dagger:hilt-android-compiler:2.28-alpha'
+    kapt "androidx.hilt:hilt-compiler:1.0.0-SNAPSHOT"
     androidTestImplementation 'com.google.dagger:hilt-android-testing:2.28-alpha'
     kaptAndroidTest 'com.google.dagger:hilt-android-compiler:2.28-alpha'
 

--- a/app/src/androidTest/java/com/deviange/daggerhilt/HiltExampleTest.kt
+++ b/app/src/androidTest/java/com/deviange/daggerhilt/HiltExampleTest.kt
@@ -1,6 +1,10 @@
 package com.deviange.daggerhilt
 
-import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.deviange.featuremodule.Feature
 import com.deviange.featuremodule.FeatureModule
@@ -25,6 +29,9 @@ class HiltExampleTest {
     @get:Rule
     var hiltRule = HiltAndroidRule(this)
 
+    @get:Rule
+    var activityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
     private val testFeature = TestFeature()
 
     @BindValue
@@ -33,8 +40,16 @@ class HiltExampleTest {
 
     @Test
     fun verifySomethingIsDone() {
-        launch(MainActivity::class.java)
         Assert.assertEquals(testFeature.invocationCount, 1)
+    }
+
+    @Test
+    fun verifyCounterIsDisplayedCorrectly_AcrossRecreation() {
+        onView(withText("MainFragment Counter: 1")).check(matches(isDisplayed()))
+
+        activityScenarioRule.scenario.recreate()
+
+        onView(withText("MainFragment Counter: 2")).check(matches(isDisplayed()))
     }
 
     class TestFeature : Feature {

--- a/app/src/main/java/com/deviange/daggerhilt/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/deviange/daggerhilt/ui/main/MainFragment.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.deviange.daggerhilt.R
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,7 +28,18 @@ class MainFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         viewModel = ViewModelProviders.of(this).get(MainViewModel::class.java)
-        // TODO: Use the ViewModel
+
+        val messageTextView = requireView().findViewById<TextView>(R.id.message)
+        viewModel.counterState.observe(viewLifecycleOwner, Observer { counter ->
+            messageTextView.text = "MainFragment Counter: $counter"
+        })
     }
 
+    override fun onStop() {
+        super.onStop()
+        if (requireActivity().isChangingConfigurations) {
+            val previousValue = viewModel.counterState.value!!
+            viewModel.counterState.postValue(previousValue + 1)
+        }
+    }
 }

--- a/app/src/main/java/com/deviange/daggerhilt/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/deviange/daggerhilt/ui/main/MainViewModel.kt
@@ -1,7 +1,16 @@
 package com.deviange.daggerhilt.ui.main
 
+import androidx.hilt.Assisted
+import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.deviange.daggerhilt.Repository
 
-class MainViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
+class MainViewModel @ViewModelInject constructor(
+    // Not used but to demonstrate that other objects in the graph can be injected.
+    private val repository: Repository,
+    @Assisted private val savedStateHandle: SavedStateHandle
+): ViewModel() {
+
+    val counterState = savedStateHandle.getLiveData("counter", 1)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     repositories {
         google()
         jcenter()
-        
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.2'
@@ -21,7 +21,9 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
+        maven {
+            url "https://androidx.dev/snapshots/builds/6518514/artifacts/repository/"
+        }
     }
 }
 


### PR DESCRIPTION
AndroidX has hilt support in progress (It is still in early stages though). 

The PR demonstrates the usage of `@ViewModelInject` along with `@Assisted` usage that helps in injecting a `SavedStateHandle` to support state restoration. 

One drawback I found, is that it doesn't work with FragmentScenario since Hilt needs an Activity that's annotated with `@AndroidEntryPoint` and the FragmentScenario instantiates a stub activity that hosts the fragment under test, however I expect that they will fix it somehow in later releases. 